### PR TITLE
Provide a default query if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,23 @@ CWQ is designed for fast searching and presentation of log data in multiple form
 The basic command structure is:
 
 ```bash
-cwq --log-group <log-group> '<query>'
+cwq --log-group <log-group>
 ```
 
-Where `<log-group>` is the log group you want to search and `<query>` is the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) to search with.
+`<log-group>` is the log group you want to search. 
+
+If not specified, the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) will default to:
+
+```
+fields @timestamp, @message, @logStream, @log
+| sort @timestamp desc
+```
+
+
+To execute a custom query, provide it as the first positional parameter:
+ ```bash
+ cwq --log-group <log-group> '<query>'
+ ```
 
 Further usage guidelines are described below and options can be found via the help argument:
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,10 @@ CWQ is designed for fast searching and presentation of log data in multiple form
 The basic command structure is:
 
 ```bash
-cwq --log-group <log-group>
+cwq --log-group <log-group> '<query>'
 ```
 
-`<log-group>` is the log group you want to search. 
-
-If not specified, the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) will default to:
-
-```
-fields @timestamp, @message, @logStream, @log
-| sort @timestamp desc
-```
-
-
-To execute a custom query, provide it as the first positional parameter:
- ```bash
- cwq --log-group <log-group> '<query>'
- ```
+Where `<log-group>` is the log group you want to search and `<query>` is the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) to search with.
 
 Further usage guidelines are described below and options can be found via the help argument:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ cwq --log-group <log-group> '<query>'
 
 Where `<log-group>` is the log group you want to search and `<query>` is the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) to search with.
 
+If `<query>` is not specified, the [CloudWatch Logs Insights query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html) will default to:
+
+```
+fields @timestamp, @message, @logStream, @log
+| sort @timestamp desc
+```
+
 Further usage guidelines are described below and options can be found via the help argument:
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,15 @@ process.on("SIGINT", async () => {
   const endTime = time.parseTimeOrDuration(args.end);
   const limit = args.limit;
 
-  const query = args._[0];
+  let query = args._[0];
   if (!query) {
-    throw new Error("No query provided");
+    query = `
+      fields @timestamp, @message, @logStream, @log
+      | sort @timestamp desc
+    `;
+    console.error(
+      `No Cloudwatch Insight Query provided. Defaulting to: \n${query}`
+    );
   }
   const queryString = query.toString();
 


### PR DESCRIPTION
**Old Behavior**

If the query parameter was not provided - the `[0]` arg - then an error would be returned
```
No query provided
```

**New Behavior**

This merge request defaults the query to 
```
      fields @timestamp, @message, @logStream, @log
      | sort @timestamp desc
```

(if not provided).

**Testing**

Screenshot of the output from a manual test
```
No Cloudwatch Insight Query provided. Defaulting to:

      fields @timestamp, @message, @logStream, @log
      | sort @timestamp desc

Querying between 2023-10-06T20:43:15.096Z and 2023-10-06T21:43:15.096Z
    for 1 log group(s): ["/aws/lambda/CoreAPI-processesTaskGeneratePatientExport"]

    0 records (0.00 MB) scanned, 0 matched

No results returned.
```